### PR TITLE
Explicit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,56 @@
 
 # Usage
 ## Static string
-`<perch:translate id="myTranslation1" en="Static string" fr="Contenu static" />`
+```html
+<perch:translate id="myTranslation1" en="Static string" fr="Contenu static" />
+```
 
 ## perch:content
 To use dynamic content coming from `<perch:content />`, specify the id in `<perch:translate />`.
 
-`<perch:content id="content_en" type="text" />`
-`<perch:content id="content_fr" type="text" />`
+```html
+<perch:content id="content_en" type="text" />
+<perch:content id="content_fr" type="text" />
+```
 
 Can then be used:
-`<perch:translate id="myTranslation2" en="content_en" fr="content_fr" />`
+```html
+<perch:translate id="myTranslation2" en="content_en" fr="content_fr" />
+```
+
+
+## Explicit mode
+By default if the app doesn't find dynamic content matching the ID giving in a language attribute, it will assume it's static content and output it as is.
+
+If you're on `/fr` and attempt to output `name` but you haven't added the `fr` translation:
+
+```html
+<perch:translate id="name_en" en="name_en" fr="name_fr" />
+```
+
+The app outputs "name_fr".
+
+In explicit mode, you tell the app which ID is for dynamic content by wrapping it in `{}`:
+
+```html
+<perch:translate id="name_en" en="{name_en}" fr="{name_fr}" explicit />
+```
+
+If no dynamic content with ID `name_fr` is found, the app then falls back to the `id` attribute and output the dynamic content with ID `name_en` in this case.
+
+
+You can also mix between dynamic and static content:
+
+```html
+<perch:translate id="name" en="Some static content" fr="{name_fr}" explicit />
+```
+
+### Turning on explicit mode
+
+You can turn explicit mode per tag by adding the `explicit` attribute. If you are using an older version of Perch, you also need to give it a value `explicit="true"`.
+
+If you prefer to have explicit mode turned on globally for all your `perch:translate` tags, add the following to your Perch configuration file `perch/config/config.php`:
+
+```php
+define('RP_TRANSLATION_HELPER_EXPLICIT_MODE', true);
+```

--- a/rp_translationhelper/lib/RpTranslationhelper_Template.class.php
+++ b/rp_translationhelper/lib/RpTranslationhelper_Template.class.php
@@ -21,9 +21,16 @@ class RpTranslationhelper_Template extends PerchAPI_TemplateHandler
           // explicit mode enabled on $Tag or in config
           if($Tag->explicit || $explicit_mode) {
 
-            if(substr($Tag->$lang, 0, strlen('{')) === '{') {
+            if(substr($Tag->$lang, 0, 1) === '{') {
+
               $lang_id = trim($Tag->$lang, '{}');
-              $value = isset($vars[$lang_id]) ? $vars[$lang_id] : $vars[$Tag->id];
+
+              if(isset($vars[$lang_id])) {
+                $value = $vars[$lang_id];
+              } elseif(isset($vars[$Tag->id])) {
+                $value = $vars[$Tag->id];
+              }
+              
             } else {
               $value = $Tag->$lang;
             }

--- a/rp_translationhelper/lib/RpTranslationhelper_Template.class.php
+++ b/rp_translationhelper/lib/RpTranslationhelper_Template.class.php
@@ -7,12 +7,33 @@ class RpTranslationhelper_Template extends PerchAPI_TemplateHandler
     public function render($vars, $html, $Template) {
       $lang = PerchSystem::get_var('lang');
 
+      // Explicit mode not enabled by default
+      $explicit_mode = false;
+      if(defined('RP_TRANSLATION_HELPER_EXPLICIT_MODE')) $explicit_mode = RP_TRANSLATION_HELPER_EXPLICIT_MODE;
+
       if(strpos($html, 'perch:translate') !== false) {
         $translatedValues = array();
         $tags = $Template->find_all_tags('translate');
 
         foreach($tags as $Tag) {
-          $translatedValues[$Tag->id] = isset($vars[$Tag->$lang]) ? $vars[$Tag->$lang] : $Tag->$lang;
+          $value = $lang_id = '';
+
+          // explicit mode enabled on $Tag or in config
+          if($Tag->explicit || $explicit_mode) {
+
+            if(substr($Tag->$lang, 0, strlen('{')) === '{') {
+              $lang_id = trim($Tag->$lang, '{}');
+              $value = isset($vars[$lang_id]) ? $vars[$lang_id] : $vars[$Tag->id];
+            } else {
+              $value = $Tag->$lang;
+            }
+
+          } else {
+            $value = isset($vars[$Tag->$lang]) ? $vars[$Tag->$lang] : $Tag->$lang;
+          }
+          
+          
+          $translatedValues[$Tag->id] = $value;
         }
 
         $html = $Template->replace_content_tags('translate', $translatedValues, $html);


### PR DESCRIPTION
Hello,

I've added an explicit mode to give developers more control on how the app determines whether the translated content is static or dynamic. This is mainly to handle cases in which the dynamic translated content is not present (e.g. editors have not added it yet).

The addition of the explicit mode does not introduce any breaking changes to existing sites as it is not enabled by default.


## Without explicit mode

Consider this scenario: you have the following fields `name_en`, `name_fr` and `name_ru`. Editors have entered `name_en` and `name_fr`, but not `name_ru`.

And you have the following tag:

```html
<perch:translate id="name_en" en="name_en" fr="name_fr" ru="name_ru" />
```

Since the field `name_ru` has not been filled, it won't be present as in the `$vars` array. Without explicit mode the app assumes this is static content and returns the string "name_ru".


## With explicit mode

With explicit mode you wrap dynamic content IDs with `{}` to tell the app these are dynamic. Otherwise the app consider them static content.

```html
<perch:translate id="name_en" en="{name_en}" fr="{name_fr}" ru="{name_ru}" explicit />
```

In the same scenario in which `name_ru` is not present, explicit mode falls back to the value in the `id` attribute (as a dynamic content). If even that is not present, an empty string is returned.

So in this case if the Russian name `ru={name_ru}` isn't present, the English name `id="name_en"` is used as a fall back.